### PR TITLE
Fix: Download link for windows is broken

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -47,7 +47,7 @@ export default class extends Component {
           icon: 'windows',
           title: 'Windows',
           primary: ua.os.name === 'Windows',
-          fileName: 'buttercup-desktop-setup-{version}.exe'
+          fileName: 'Buttercup-Setup-{version}.exe'
         },
         {
           icon: 'linux',


### PR DESCRIPTION
Fixed error 404 on the ButterCup Desktop Windows download link. #50
Changed the file name for windows.