### PR TITLE
Update macos brew install command

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -190,7 +190,7 @@ export default class extends Component {
                 </div>
                 <div className="content is-small">
                   <p>
-                    Alternatively, using Homebrew: <code>$ brew cask install buttercup</code>
+                    Alternatively, using Homebrew: <code>$ brew install --cask buttercup</code>
                     <br />
                     Latest: <strong className="version">{this.state.version}</strong>.{' '}
                     <a href="https://github.com/buttercup/buttercup-desktop/releases" rel="noopener" target="_blank">


### PR DESCRIPTION
Homebrew casks are now installed with `brew install --cask`.