### PR TITLE
Update browser extensions section so users are now aware about the dependency on the desktop application

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -284,6 +284,13 @@ export default class extends Component {
                 </div>
               </div>
             </section>
+            <div className="content">
+              <p>
+                Note: the extension <strong>requires the Buttercup desktop application version 2.26 or later</strong> be
+                installed <i>and</i> running, at least in the background. This browser addon uses an encrypted connection with the desktop application
+                to transfer vault credentials during login and saving. This addon cannot function without the desktop application.
+              </p>
+            </div>
           </div>
         </section>
         <section className="section section-awards">


### PR DESCRIPTION
The new version 3 of the extension is now requiring the Buttercup Desktop application be installed and running. This a change in response to the upcoming Manifest V3 adopted by Google Chrome.

While the extension is now stating this requirement in the README file and in its notification tab, the user was left unaware of this requirement when downloading the extension.

Fix some warnings seen while testing the change.